### PR TITLE
feat: create WhatsApp to n8n bridge service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+PORT=3000
+N8N_WEBHOOK_URL=https://seu-n8n.com/webhook/whatsapp
+PUBLIC_BASE_URL=https://seu-servidor.com
+MEDIA_DIR=./media
+WHATSAPP_SESSION_DIR=./session
+REPLY_API_KEY=troque-esta-chave
+LOG_LEVEL=info

--- a/README.md
+++ b/README.md
@@ -1,1 +1,176 @@
-# whatsapp-interface
+# WhatsApp ↔️ n8n Bridge
+
+Bridge em Node.js que integra o [whatsapp-web.js](https://github.com/pedroslopez/whatsapp-web.js) com um fluxo no [n8n](https://n8n.io/). Recebe mensagens de clientes no WhatsApp, encaminha para um webhook HTTP no n8n e expõe um endpoint para que o n8n devolva respostas (texto, botões ou mídia) para o usuário final.
+
+## Requisitos
+
+- Node.js 18 ou superior
+- Conta WhatsApp Business ou número comum com acesso ao WhatsApp Web
+- Acesso a um servidor HTTP público para hospedar o bridge (para que o n8n consiga consumir as URLs de mídia)
+
+## Instalação
+
+```bash
+npm install
+```
+
+Crie um arquivo `.env` baseado no modelo:
+
+```bash
+cp .env.example .env
+```
+
+Edite os valores conforme o seu ambiente:
+
+| Variável                | Descrição                                                                                  |
+| ----------------------- | ------------------------------------------------------------------------------------------ |
+| `PORT`                  | Porta do servidor Express (padrão: `3000`).                                                |
+| `N8N_WEBHOOK_URL`       | Webhook HTTP (POST) do n8n que receberá os eventos das mensagens do WhatsApp.              |
+| `PUBLIC_BASE_URL`       | URL pública deste bridge (ex.: `https://seu-dominio.com`). Usada para gerar URLs de mídia. |
+| `MEDIA_DIR`             | Pasta local para armazenar mídias temporárias (padrão `./media`).                          |
+| `WHATSAPP_SESSION_DIR`  | Pasta onde a sessão autenticada do WhatsApp será persistida (padrão `./session`).          |
+| `REPLY_API_KEY`         | Chave secreta para autenticar chamadas ao endpoint `/api/reply`.                           |
+| `LOG_LEVEL`             | Nível de log aceito pelo [pino](https://github.com/pinojs/pino) (`info`, `debug`, etc.).    |
+
+> ⚠️ Garanta que `PUBLIC_BASE_URL` seja acessível pelo n8n e que esteja configurado atrás de HTTPS quando em produção.
+
+## Executando
+
+### Desenvolvimento
+
+```bash
+npm run dev
+```
+
+O comando acima usa `nodemon` para recarregar o servidor automaticamente ao alterar os arquivos.
+
+### Produção
+
+```bash
+npm start
+```
+
+Na primeira execução será exibido um QR Code no terminal; escaneie com o WhatsApp do número que deseja conectar. A sessão autenticada ficará salva no diretório informado em `WHATSAPP_SESSION_DIR`.
+
+## Fluxo de mensagens
+
+1. O cliente envia uma mensagem (texto ou mídia) para o seu número WhatsApp.
+2. O bridge captura o evento, salva mídias localmente e dispara um POST para `N8N_WEBHOOK_URL` com os metadados.
+3. O n8n processa o evento e, quando desejar enviar uma resposta ao usuário, realiza um POST em `/api/reply` (com o header `X-API-KEY`).
+4. O bridge envia a resposta ao usuário via WhatsApp.
+
+### Payload enviado ao n8n para mensagens de texto
+
+```json
+{
+  "type": "text",
+  "from": "5511999999999@c.us",
+  "chatId": "5511999999999@c.us",
+  "messageId": "ABCDEF1234567890",
+  "text": "Olá, gostaria de saber o status do pedido",
+  "timestamp": 1699999999
+}
+```
+
+### Payload enviado ao n8n para mensagens com mídia
+
+```json
+{
+  "type": "media",
+  "mediaKind": "image",
+  "from": "5511999999999@c.us",
+  "chatId": "5511999999999@c.us",
+  "messageId": "ABCDEF1234567890",
+  "mimeType": "image/jpeg",
+  "mediaUrl": "https://seu-dominio.com/media/3f1b0a8c-2d4e-4e94-8b93-4fe77f4c2ef3.jpg",
+  "caption": "Comprovante",
+  "timestamp": 1699999999
+}
+```
+
+A URL de mídia é válida por 24 horas (limpeza automática). O arquivo é armazenado em `MEDIA_DIR` e servido estaticamente pela rota `/media/*`.
+
+## Endpoint de resposta para o n8n
+
+- **URL:** `POST /api/reply`
+- **Header obrigatório:** `X-API-KEY: <REPLY_API_KEY>`
+- **Body:** JSON conforme exemplos abaixo.
+
+### Resposta de texto
+
+```json
+{
+  "chatId": "5511999999999@c.us",
+  "text": "Pedido #123 confirmado com sucesso!"
+}
+```
+
+### Resposta com botões
+
+```json
+{
+  "chatId": "5511999999999@c.us",
+  "text": "Confirma o pedido?",
+  "buttons": [
+    { "id": "approve_all", "text": "✅ Aprovar Tudo" },
+    { "id": "edit_lines", "text": "✏️ Editar Itens" }
+  ]
+}
+```
+
+### Resposta com lista
+
+```json
+{
+  "chatId": "5511999999999@c.us",
+  "text": "Selecione uma opção",
+  "list": {
+    "buttonText": "Abrir opções",
+    "sections": [
+      {
+        "title": "Pedidos",
+        "rows": [
+          { "id": "order_status", "title": "Consultar status" },
+          { "id": "cancel_order", "title": "Cancelar pedido" }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### Resposta com mídia
+
+```json
+{
+  "chatId": "5511999999999@c.us",
+  "media": {
+    "url": "https://meu-arquivo.com/preview.pdf",
+    "caption": "Seu pedido"
+  }
+}
+```
+
+> O bridge irá baixar o arquivo (até 20 MB) e enviá-lo ao usuário com o caption opcional.
+
+## Webhook no n8n
+
+No n8n, crie um workflow com um nó **Webhook** configurado para `POST` e utilize a URL informada na variável `N8N_WEBHOOK_URL`. Esse nó receberá o payload das mensagens. A partir dele, seu fluxo pode processar as informações e usar um nó **HTTP Request** para chamar `POST /api/reply` quando precisar responder ao usuário.
+
+## Monitoramento & Logs
+
+- Logs estruturados utilizando [pino](https://github.com/pinojs/pino).
+- QR Code para autenticação exibido diretamente no terminal (via `qrcode-terminal`).
+- Limpeza automática de mídias com mais de 24 horas.
+- Tratamento de retentativas com backoff exponencial para envio ao n8n.
+
+## Scripts úteis
+
+| Comando         | Descrição                                   |
+| --------------- | ------------------------------------------- |
+| `npm run dev`   | Inicia servidor com recarregamento automático. |
+| `npm start`     | Inicia servidor em modo produção.              |
+
+## Licença
+
+MIT

--- a/package.json
+++ b/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "whatsapp-n8n-bridge",
+  "version": "1.0.0",
+  "description": "Bridge entre WhatsApp e n8n usando whatsapp-web.js e Express",
+  "main": "src/app.js",
+  "type": "commonjs",
+  "scripts": {
+    "start": "node src/app.js",
+    "dev": "nodemon src/app.js"
+  },
+  "keywords": [
+    "whatsapp",
+    "n8n",
+    "bridge"
+  ],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "axios": "^1.6.7",
+    "dotenv": "^16.4.5",
+    "express": "^4.18.3",
+    "multer": "^1.4.5-lts.1",
+    "pino": "^8.17.0",
+    "qrcode-terminal": "^0.12.0",
+    "whatsapp-web.js": "^1.22.2"
+  },
+  "devDependencies": {
+    "nodemon": "^3.0.3",
+    "pino-pretty": "^10.3.1"
+  }
+}

--- a/src/app.js
+++ b/src/app.js
@@ -1,0 +1,54 @@
+require('dotenv').config();
+
+const express = require('express');
+const path = require('path');
+const logger = require('./logger');
+const mediaStore = require('./services/mediaStore');
+const createN8NClient = require('./services/n8nClient');
+const createWhatsappClient = require('./whatsapp');
+const healthRouter = require('./routes/health');
+const createInboundRouter = require('./routes/inbound');
+
+const app = express();
+
+app.use(express.json({ limit: '5mb' }));
+app.use(express.urlencoded({ extended: true }));
+
+const port = process.env.PORT || 3000;
+const mediaDir = path.resolve(process.cwd(), process.env.MEDIA_DIR || './media');
+
+mediaStore.initialize({ mediaDir, publicBaseUrl: process.env.PUBLIC_BASE_URL });
+mediaStore.scheduleCleanup();
+
+const n8nClient = createN8NClient({ webhookUrl: process.env.N8N_WEBHOOK_URL });
+const whatsappClient = createWhatsappClient({
+  mediaStore,
+  n8nClient,
+  sessionDir: process.env.WHATSAPP_SESSION_DIR
+});
+
+app.use(
+  '/media',
+  express.static(mediaDir, {
+    setHeaders: (res) => {
+      res.setHeader('Cache-Control', 'no-store');
+      res.setHeader('Pragma', 'no-cache');
+      res.setHeader('Expires', new Date(Date.now() + 24 * 60 * 60 * 1000).toUTCString());
+    }
+  })
+);
+
+app.use('/health', healthRouter);
+app.use('/api', createInboundRouter({ client: whatsappClient, replyApiKey: process.env.REPLY_API_KEY }));
+
+app.use((err, req, res, next) => {
+  logger.error({ err: err.message, stack: err.stack }, 'Erro não tratado na aplicação Express');
+  res.status(500).json({ ok: false, error: 'Erro interno' });
+});
+
+app.listen(port, () => {
+  logger.info({ port }, 'Servidor Express iniciado');
+  whatsappClient.initialize();
+});
+
+module.exports = app;

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,0 +1,16 @@
+const pino = require('pino');
+
+const logger = pino({
+  level: process.env.LOG_LEVEL || 'info',
+  transport: process.env.NODE_ENV !== 'production'
+    ? {
+        target: 'pino-pretty',
+        options: {
+          colorize: true,
+          translateTime: 'SYS:standard'
+        }
+      }
+    : undefined
+});
+
+module.exports = logger;

--- a/src/routes/health.js
+++ b/src/routes/health.js
@@ -1,0 +1,9 @@
+const express = require('express');
+
+const router = express.Router();
+
+router.get('/', (req, res) => {
+  res.json({ status: 'ok' });
+});
+
+module.exports = router;

--- a/src/routes/inbound.js
+++ b/src/routes/inbound.js
@@ -1,0 +1,101 @@
+const express = require('express');
+const axios = require('axios');
+const { MessageMedia, Buttons, List } = require('whatsapp-web.js');
+const logger = require('../logger');
+
+const MAX_MEDIA_SIZE = 20 * 1024 * 1024; // 20MB
+
+function createInboundRouter({ client, replyApiKey }) {
+  if (!client) {
+    throw new Error('WhatsApp client não definido');
+  }
+
+  const router = express.Router();
+
+  router.use((req, res, next) => {
+    if (!replyApiKey) {
+      logger.warn('REPLY_API_KEY não configurado - negando acesso');
+      return res.status(401).json({ ok: false, error: 'Unauthorized' });
+    }
+
+    const headerKey = req.headers['x-api-key'];
+    if (!headerKey || headerKey !== replyApiKey) {
+      logger.warn({ headerKey }, 'Tentativa de acesso não autorizada ao endpoint /api/reply');
+      return res.status(401).json({ ok: false, error: 'Unauthorized' });
+    }
+
+    return next();
+  });
+
+  router.post('/reply', async (req, res) => {
+    const { chatId, text, buttons, list, media } = req.body || {};
+
+    if (!chatId) {
+      return res.status(400).json({ ok: false, error: 'chatId é obrigatório' });
+    }
+
+    try {
+      logger.info({ chatId, text: text ? text.slice(0, 60) : undefined }, 'Recebida solicitação de resposta do n8n');
+
+      if (media && media.url) {
+        await sendMediaMessage({ client, chatId, media });
+      } else if (Array.isArray(buttons) && buttons.length > 0) {
+        await sendButtonsMessage({ client, chatId, text, buttons });
+      } else if (list && Array.isArray(list.sections)) {
+        await sendListMessage({ client, chatId, list, text });
+      } else if (text) {
+        await client.sendMessage(chatId, text);
+      } else {
+        return res.status(400).json({ ok: false, error: 'Nenhum conteúdo para enviar' });
+      }
+
+      return res.json({ ok: true });
+    } catch (err) {
+      logger.error({ err: err.message, chatId }, 'Erro ao enviar mensagem ao WhatsApp');
+      return res.status(500).json({ ok: false, error: 'Falha ao enviar mensagem' });
+    }
+  });
+
+  return router;
+}
+
+async function sendMediaMessage({ client, chatId, media }) {
+  const response = await axios.get(media.url, {
+    responseType: 'arraybuffer',
+    maxContentLength: MAX_MEDIA_SIZE,
+    maxBodyLength: MAX_MEDIA_SIZE,
+    timeout: 20000
+  });
+
+  const mimeType = response.headers['content-type'] || 'application/octet-stream';
+  const buffer = Buffer.from(response.data);
+  const base64 = buffer.toString('base64');
+  const filename = media.filename || `media-${Date.now()}`;
+  const messageMedia = new MessageMedia(mimeType, base64, filename);
+
+  await client.sendMessage(chatId, messageMedia, {
+    caption: media.caption
+  });
+  logger.info({ chatId, mimeType, url: media.url }, 'Mídia enviada para o usuário via WhatsApp');
+}
+
+async function sendButtonsMessage({ client, chatId, text, buttons }) {
+  const formattedButtons = buttons.map((button) => ({ id: button.id, body: button.text }));
+  const message = new Buttons(text || 'Selecione uma opção:', formattedButtons, '', '');
+  await client.sendMessage(chatId, message);
+  logger.info({ chatId, buttons: formattedButtons }, 'Mensagem com botões enviada');
+}
+
+async function sendListMessage({ client, chatId, list, text }) {
+  const message = new List(
+    text || list.body || 'Selecione uma opção',
+    list.buttonText || 'Abrir menu',
+    list.sections,
+    list.title || '',
+    list.footer || ''
+  );
+  await client.sendMessage(chatId, message);
+  logger.info({ chatId }, 'Mensagem em lista enviada');
+}
+
+module.exports = createInboundRouter;

--- a/src/services/mediaStore.js
+++ b/src/services/mediaStore.js
@@ -1,0 +1,92 @@
+const fs = require('fs');
+const path = require('path');
+const { generateMediaFilename, resolvePublicUrl } = require('../utils/mime');
+const logger = require('../logger');
+
+const TWENTY_FOUR_HOURS_MS = 24 * 60 * 60 * 1000;
+
+let mediaDir;
+let publicBaseUrl;
+let cleanupInterval;
+
+function initialize(options = {}) {
+  mediaDir = options.mediaDir || path.resolve(process.cwd(), process.env.MEDIA_DIR || './media');
+  publicBaseUrl = options.publicBaseUrl || process.env.PUBLIC_BASE_URL;
+
+  if (!mediaDir) {
+    throw new Error('MEDIA_DIR is not configured');
+  }
+
+  if (!publicBaseUrl) {
+    throw new Error('PUBLIC_BASE_URL is not configured');
+  }
+
+  if (!fs.existsSync(mediaDir)) {
+    fs.mkdirSync(mediaDir, { recursive: true });
+  }
+}
+
+async function saveMedia(media) {
+  if (!media || !media.data || !media.mimetype) {
+    throw new Error('Media payload inválido');
+  }
+
+  const buffer = Buffer.from(media.data, 'base64');
+  const filename = generateMediaFilename(media.mimetype);
+  const filePath = path.join(mediaDir, filename);
+
+  await fs.promises.writeFile(filePath, buffer);
+  logger.info({ filename, filePath }, 'Mídia salva no disco');
+
+  const publicUrl = resolvePublicUrl(publicBaseUrl, `/media/${filename}`);
+
+  return {
+    filename,
+    filePath,
+    publicUrl,
+    mimeType: media.mimetype
+  };
+}
+
+function getMediaDir() {
+  if (!mediaDir) {
+    throw new Error('MediaStore não inicializado');
+  }
+  return mediaDir;
+}
+
+function scheduleCleanup() {
+  if (!mediaDir) {
+    throw new Error('MediaStore não inicializado');
+  }
+
+  if (cleanupInterval) {
+    clearInterval(cleanupInterval);
+  }
+
+  cleanupInterval = setInterval(async () => {
+    try {
+      const files = await fs.promises.readdir(mediaDir);
+      const now = Date.now();
+      await Promise.all(
+        files.map(async (file) => {
+          const filePath = path.join(mediaDir, file);
+          const stat = await fs.promises.stat(filePath);
+          if (now - stat.mtimeMs > TWENTY_FOUR_HOURS_MS) {
+            await fs.promises.unlink(filePath);
+            logger.info({ filePath }, 'Mídia expirada removida');
+          }
+        })
+      );
+    } catch (err) {
+      logger.error({ err }, 'Erro durante limpeza de mídias');
+    }
+  }, 60 * 60 * 1000);
+}
+
+module.exports = {
+  initialize,
+  saveMedia,
+  getMediaDir,
+  scheduleCleanup
+};

--- a/src/services/n8nClient.js
+++ b/src/services/n8nClient.js
@@ -1,0 +1,45 @@
+const axios = require('axios');
+const logger = require('../logger');
+
+const DEFAULT_MAX_ATTEMPTS = 3;
+const BASE_DELAY_MS = 500;
+
+function createN8NClient({ webhookUrl, maxAttempts = DEFAULT_MAX_ATTEMPTS } = {}) {
+  const resolvedWebhook = webhookUrl || process.env.N8N_WEBHOOK_URL;
+  if (!resolvedWebhook) {
+    throw new Error('N8N_WEBHOOK_URL não configurado');
+  }
+
+  async function sendEvent(payload) {
+    if (!payload) {
+      throw new Error('Payload inválido para envio ao n8n');
+    }
+
+    for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+      try {
+        await axios.post(resolvedWebhook, payload, {
+          headers: {
+            'Content-Type': 'application/json'
+          },
+          timeout: 15000
+        });
+        logger.info({ attempt, payloadType: payload.type, chatId: payload.chatId, messageId: payload.messageId }, 'Evento enviado ao n8n');
+        return true;
+      } catch (err) {
+        const delay = BASE_DELAY_MS * 2 ** (attempt - 1);
+        logger.error({ err: err.message, attempt, delay, chatId: payload.chatId, messageId: payload.messageId }, 'Falha ao enviar evento ao n8n');
+        if (attempt === maxAttempts) {
+          throw err;
+        }
+        await new Promise((resolve) => setTimeout(resolve, delay));
+      }
+    }
+    return false;
+  }
+
+  return {
+    sendEvent
+  };
+}
+
+module.exports = createN8NClient;

--- a/src/utils/mime.js
+++ b/src/utils/mime.js
@@ -1,0 +1,59 @@
+const crypto = require('crypto');
+
+const MIME_EXTENSION_MAP = {
+  'image/jpeg': '.jpg',
+  'image/png': '.png',
+  'image/gif': '.gif',
+  'image/webp': '.webp',
+  'audio/mpeg': '.mp3',
+  'audio/ogg': '.ogg',
+  'audio/wav': '.wav',
+  'video/mp4': '.mp4',
+  'video/3gpp': '.3gp',
+  'application/pdf': '.pdf',
+  'application/zip': '.zip',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document': '.docx'
+};
+
+function getExtensionFromMime(mimeType = '') {
+  if (!mimeType) return '';
+  if (MIME_EXTENSION_MAP[mimeType]) {
+    return MIME_EXTENSION_MAP[mimeType];
+  }
+
+  const parts = mimeType.split('/');
+  if (parts.length !== 2) {
+    return '';
+  }
+
+  const subtype = parts[1].split(';')[0];
+  if (!subtype) {
+    return '';
+  }
+
+  return `.${subtype}`;
+}
+
+function sanitizeFilename(filename = '') {
+  return filename.replace(/[^a-zA-Z0-9-_\.]/g, '_');
+}
+
+function generateMediaFilename(mimeType) {
+  const extension = getExtensionFromMime(mimeType);
+  return `${crypto.randomUUID()}${extension}`;
+}
+
+function resolvePublicUrl(baseUrl, relativePath) {
+  if (!baseUrl) {
+    throw new Error('PUBLIC_BASE_URL is not configured.');
+  }
+  const normalized = relativePath.startsWith('/') ? relativePath.slice(1) : relativePath;
+  return new URL(normalized, baseUrl).toString();
+}
+
+module.exports = {
+  getExtensionFromMime,
+  sanitizeFilename,
+  generateMediaFilename,
+  resolvePublicUrl
+};

--- a/src/whatsapp.js
+++ b/src/whatsapp.js
@@ -1,0 +1,137 @@
+const path = require('path');
+const qrcode = require('qrcode-terminal');
+const { Client, LocalAuth } = require('whatsapp-web.js');
+const logger = require('./logger');
+
+const MEDIA_KIND_MAP = {
+  image: 'image',
+  video: 'video',
+  audio: 'audio',
+  ptt: 'audio',
+  document: 'document',
+  sticker: 'sticker',
+  voice: 'audio'
+};
+
+function createWhatsappClient({ mediaStore, n8nClient, sessionDir }) {
+  if (!mediaStore) {
+    throw new Error('mediaStore é obrigatório');
+  }
+  if (!n8nClient) {
+    throw new Error('n8nClient é obrigatório');
+  }
+
+  const resolvedSessionDir = sessionDir || process.env.WHATSAPP_SESSION_DIR || './session';
+
+  const client = new Client({
+    authStrategy: new LocalAuth({
+      dataPath: path.resolve(process.cwd(), resolvedSessionDir)
+    }),
+    puppeteer: {
+      headless: true,
+      args: ['--no-sandbox', '--disable-setuid-sandbox']
+    }
+  });
+
+  client.on('qr', (qr) => {
+    logger.info('QR Code recebido. Escaneie para autenticar.');
+    qrcode.generate(qr, { small: true });
+  });
+
+  client.on('ready', () => {
+    logger.info('Cliente WhatsApp está pronto.');
+  });
+
+  client.on('authenticated', () => {
+    logger.info('Autenticado no WhatsApp com sucesso.');
+  });
+
+  client.on('auth_failure', (msg) => {
+    logger.error({ msg }, 'Falha de autenticação no WhatsApp');
+  });
+
+  client.on('disconnected', (reason) => {
+    logger.warn({ reason }, 'Cliente WhatsApp desconectado');
+  });
+
+  client.on('message', async (message) => {
+    if (message.fromMe) {
+      return;
+    }
+
+    const chatId = message.from;
+    const messageId = message.id && message.id._serialized ? message.id._serialized : message.id;
+    const timestamp = message.timestamp;
+
+    logger.info({ chatId, messageId, type: message.type }, 'Mensagem recebida do WhatsApp');
+
+    try {
+      if (message.hasMedia) {
+        await handleMediaMessage({ message, chatId, messageId, timestamp, mediaStore, n8nClient });
+      } else if (message.type === 'chat') {
+        await handleTextMessage({ message, chatId, messageId, timestamp, n8nClient });
+      } else {
+        logger.info({ chatId, messageId, type: message.type }, 'Tipo de mensagem não suportado para media/texto. Enviando metadados ao n8n.');
+        await n8nClient.sendEvent({
+          type: 'unknown',
+          messageType: message.type,
+          from: message.from,
+          chatId,
+          messageId,
+          timestamp
+        });
+      }
+    } catch (err) {
+      logger.error({ err: err.message, chatId, messageId }, 'Erro ao processar mensagem recebida do WhatsApp');
+    }
+  });
+
+  return client;
+}
+
+async function handleTextMessage({ message, chatId, messageId, timestamp, n8nClient }) {
+  const text = message.body || '';
+  const payload = {
+    type: 'text',
+    from: message.from,
+    chatId,
+    messageId,
+    text,
+    timestamp
+  };
+  await n8nClient.sendEvent(payload);
+}
+
+async function handleMediaMessage({ message, chatId, messageId, timestamp, mediaStore, n8nClient }) {
+  const media = await message.downloadMedia();
+  if (!media) {
+    throw new Error('Não foi possível baixar a mídia');
+  }
+
+  const saved = await mediaStore.saveMedia(media);
+  const mediaKind = MEDIA_KIND_MAP[message.type] || inferMediaKind(media.mimetype);
+
+  const payload = {
+    type: 'media',
+    mediaKind,
+    from: message.from,
+    chatId,
+    messageId,
+    mimeType: saved.mimeType,
+    mediaUrl: saved.publicUrl,
+    caption: message.caption || message.body,
+    timestamp
+  };
+
+  await n8nClient.sendEvent(payload);
+}
+
+function inferMediaKind(mimeType = '') {
+  if (mimeType.startsWith('image/')) return 'image';
+  if (mimeType.startsWith('audio/')) return 'audio';
+  if (mimeType.startsWith('video/')) return 'video';
+  if (mimeType === 'application/pdf') return 'document';
+  return 'document';
+}
+
+module.exports = createWhatsappClient;


### PR DESCRIPTION
## Summary
- implement an Express-based bridge that forwards WhatsApp messages to an n8n webhook and exposes a secured reply endpoint
- add media persistence, cleanup, and static hosting to share temporary media URLs with n8n
- document setup, environment variables, and usage flows in the README alongside an example .env file

## Testing
- ⚠️ `npm install` *(fails in sandbox: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68ddc21ab0a48333a5e93731c0f92f20